### PR TITLE
Add PEP-0561 compatible type marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,5 @@ setup(
     url="https://github.com/hardtack/autowire",
     license="MIT LICENSE",
     keywords=["dependency-injection"],
+    package_data={"autowire": ["autowire/py.typed"]},
 )


### PR DESCRIPTION
Add `py.typed` into package to support [PEP-0561](https://www.python.org/dev/peps/pep-0561/)