### PR TITLE
Add a type parameter to default_implementation

### DIFF
--- a/autowire/resource.py
+++ b/autowire/resource.py
@@ -29,7 +29,7 @@ class Resource(BaseResource[R]):
 
     def __init__(self, name: str, namespace: str):
         super().__init__(name, namespace)
-        self.default_implementation: Optional[Implementation] = None
+        self.default_implementation: Optional[Implementation[R]] = None
 
     def plain(
         self,


### PR DESCRIPTION
* Add type parameter `R` to `Implemenation` in the type of `Resource.default_implementation`

* By this, We can find a mistakenly assigned `default_implemenation` with wrong types